### PR TITLE
Changed is_booster function

### DIFF
--- a/3pseatBot/bot.py
+++ b/3pseatBot/bot.py
@@ -102,7 +102,7 @@ class Bot(commands.AutoShardedBot):
         return False
 
     def is_booster(self, guild, user):
-        if guild.premium_subscriber_role in user.roles:
+        if user in guild.premium_subscribers:
             return True
         return False
 


### PR DESCRIPTION
changed is_booster function to instead check if user is on the list of premium subscribers for that guild, instead of relying on role assignment