### PR TITLE
Add reminders extension and `/tts`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,8 +60,8 @@ repos:
     -   id: mypy
         # Add any additional typed package dependencies here
         additional_dependencies: [
-            'git+https://github.com/Rapptz/discord.py.git@b7dd97dca997fcb7b9648dab0df826a56a1ebe53',
-            'quart',
+            'git+https://github.com/Rapptz/discord.py.git@13c725f1836168eca97a5e51180625a32f3eb2cc',
+            'quart==0.17.0',
             'types-emoji',
             'types-requests'
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     Quart-Discord
     discord.py@git+https://github.com/Rapptz/discord.py.git@b7dd97dca997fcb7b9648dab0df826a56a1ebe53
     emoji
+    gtts
     pynacl
     quart==0.17.0
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find:
 install_requires =
     Quart-Discord
-    discord.py@git+https://github.com/Rapptz/discord.py.git@b7dd97dca997fcb7b9648dab0df826a56a1ebe53
+    discord.py@git+https://github.com/Rapptz/discord.py.git@13c725f1836168eca97a5e51180625a32f3eb2cc
     emoji
     gtts
     pynacl

--- a/testing/mock.py
+++ b/testing/mock.py
@@ -56,10 +56,11 @@ class MockVoiceChannel(discord.VoiceChannel):
         self.name = 'voice-channel'
         self.id = 9876
         self.guild = MockGuild('guild', 4567)
+        self._members: list[discord.Member] = []
 
     @property
     def members(self) -> list[discord.Member]:
-        return []
+        return self._members
 
 
 class MockClient(commands.Bot):

--- a/tests/bot_test.py
+++ b/tests/bot_test.py
@@ -9,6 +9,7 @@ from testing.mock import MockGuild
 from testing.mock import MockUser
 from threepseat.bot import Bot
 from threepseat.commands.custom import CustomCommands
+from threepseat.reminders.commands import ReminderCommands
 from threepseat.rules.commands import RulesCommands
 from threepseat.sounds.commands import SoundCommands
 from threepseat.sounds.data import Sounds
@@ -59,6 +60,7 @@ async def test_bot_startup(tmp_file: str, caplog) -> None:
                 custom_commands=CustomCommands(tmp_file),
                 sound_commands=SoundCommands(sounds),
                 rules_commands=RulesCommands(tmp_file),
+                reminder_commands=ReminderCommands(tmp_file),
             )
             await bot.on_ready()
 

--- a/tests/commands/tts_test.py
+++ b/tests/commands/tts_test.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from testing.mock import MockGuild
+from testing.mock import MockInteraction
+from testing.mock import MockMember
+from testing.utils import extract
+from threepseat.commands.tts import tts
+
+
+@pytest.mark.asyncio
+async def test_tts_command() -> None:
+    tts_ = extract(tts)
+
+    guild = MockGuild('guild', 5678)
+    interaction = MockInteraction(
+        tts,
+        user=MockMember('user', 1234, guild),
+        guild=guild,
+    )
+
+    with (
+        mock.patch('threepseat.commands.tts.voice_channel'),
+        mock.patch('threepseat.commands.tts.play_sound'),
+        mock.patch('threepseat.tts.gTTS'),
+    ):
+        await tts_(interaction, 'test message')
+
+    assert interaction.followed
+    assert interaction.followup_message is not None and (
+        'Played' in interaction.followup_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_tts_command_text_too_long() -> None:
+    tts_ = extract(tts)
+
+    guild = MockGuild('guild', 5678)
+    interaction = MockInteraction(
+        tts,
+        user=MockMember('user', 1234, guild),
+        guild=guild,
+    )
+
+    await tts_(interaction, 'x' * 201)
+
+    assert interaction.responded
+    assert interaction.response_message is not None and (
+        'Text length is limited' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_tts_command_not_in_voice_channel() -> None:
+    tts_ = extract(tts)
+
+    guild = MockGuild('guild', 5678)
+    interaction = MockInteraction(
+        tts,
+        user=MockMember('user', 1234, guild),
+        guild=guild,
+    )
+
+    with mock.patch(
+        'threepseat.commands.tts.voice_channel',
+        return_value=None,
+    ):
+        await tts_(interaction, 'test message')
+
+    assert interaction.followed
+    assert interaction.followup_message is not None and (
+        'must be in a voice channel' in interaction.followup_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_tts_command_exception() -> None:
+    tts_ = extract(tts)
+
+    guild = MockGuild('guild', 5678)
+    interaction = MockInteraction(
+        tts,
+        user=MockMember('user', 1234, guild),
+        guild=guild,
+    )
+
+    with (
+        mock.patch('threepseat.commands.tts.voice_channel'),
+        mock.patch(
+            'threepseat.commands.tts.play_sound',
+            side_effect=Exception(),
+        ),
+        mock.patch('threepseat.tts.gTTS'),
+    ):
+        await tts_(interaction, 'test message')
+
+    assert interaction.followed
+    assert interaction.followup_message is not None and (
+        'Failed to play TTS' in interaction.followup_message
+    )

--- a/tests/reminders/commands_test.py
+++ b/tests/reminders/commands_test.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from unittest import mock
+
+import discord
+import pytest
+
+from testing.mock import MockChannel
+from testing.mock import MockClient
+from testing.mock import MockGuild
+from testing.mock import MockInteraction
+from testing.mock import MockUser
+from testing.utils import extract
+from threepseat.reminders.commands import ReminderCommands
+from threepseat.reminders.commands import ReminderTask
+from threepseat.reminders.commands import ReminderTaskKey
+from threepseat.reminders.commands import WARN_ON_LONG_DELAY
+from threepseat.reminders.data import Reminder
+from threepseat.reminders.data import ReminderType
+
+
+REMINDER = Reminder(
+    guild_id=1234,
+    channel_id=5678,
+    author_id=9012,
+    creation_time=0,
+    name='test',
+    text='test message',
+    delay_minutes=1,
+)
+
+
+@pytest.fixture
+def reminders(tmp_file: str) -> Generator[ReminderCommands, None, None]:
+    yield ReminderCommands(tmp_file)
+
+
+@pytest.mark.asyncio
+async def test_start_repeating_reminders(reminders) -> None:
+    reminders.database.update(REMINDER._replace(name='a'))
+    reminders.database.update(REMINDER._replace(name='b'))
+
+    with mock.patch('discord.Client'):
+        client = discord.Client()  # type: ignore
+        client.guilds = [  # type: ignore
+            MockGuild('guild', REMINDER.guild_id),
+            MockGuild('guild', 42),
+        ]
+        reminders.start_repeating_reminders(client)
+
+    assert len(reminders._tasks) == 2
+
+    for key, value in list(reminders._tasks.items()):
+        reminders.stop_reminder(key.guild_id, key.name)
+        with pytest.raises(asyncio.CancelledError):
+            await value.task._task
+
+
+@pytest.mark.asyncio
+async def test_start_stop_reminder(reminders) -> None:
+    with mock.patch('discord.Client'):
+        reminders.start_reminder(
+            discord.Client(),  # type: ignore
+            REMINDER,
+            ReminderType.ONE_TIME,
+        )
+        # Task is already running so this should do nothing
+        reminders.start_reminder(
+            discord.Client(),  # type: ignore
+            REMINDER,
+            ReminderType.ONE_TIME,
+        )
+        assert len(reminders._tasks) == 1
+
+    value = reminders._tasks[ReminderTaskKey(REMINDER.guild_id, REMINDER.name)]
+    reminders.stop_reminder(REMINDER.guild_id, REMINDER.name)
+    assert len(reminders._tasks) == 0
+    with pytest.raises(asyncio.exceptions.CancelledError):
+        await value.task._task
+
+    # Should be idempotent
+    reminders.stop_reminder(REMINDER.guild_id, REMINDER.name)
+
+
+@pytest.mark.asyncio
+async def test_autocomplete(reminders) -> None:
+    interaction = MockInteraction(
+        None,  # type: ignore
+        user='calling-user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+    assert len(await reminders.autocomplete(interaction, current='')) == 0
+
+    with mock.patch('discord.Client'):
+        reminders.start_reminder(
+            discord.Client(),  # type: ignore
+            REMINDER._replace(name='a'),
+            ReminderType.ONE_TIME,
+        )
+        reminders.start_reminder(
+            discord.Client(),  # type: ignore
+            REMINDER._replace(name='b'),
+            ReminderType.ONE_TIME,
+        )
+    assert len(await reminders.autocomplete(interaction, current='')) == 2
+    assert len(await reminders.autocomplete(interaction, current='c')) == 0
+
+    tasks = [value.task for value in reminders._tasks.values()]
+    reminders.stop_reminder(REMINDER.guild_id, 'a')
+    reminders.stop_reminder(REMINDER.guild_id, 'b')
+    for task in tasks:
+        with pytest.raises(asyncio.CancelledError):
+            await task._task
+
+
+@pytest.mark.asyncio
+async def test_one_time_reminders_delete_themselves(reminders) -> None:
+    with mock.patch(
+        'threepseat.reminders.utils.send_text_reminder',
+    ) as mock_send:
+        client = MockClient(MockUser('user', 1234))
+        guild = MockGuild('guild', 5678)
+        channel = MockChannel('channel', 9012)
+        client.get_guild = mock.MagicMock(return_value=guild)
+        guild.get_channel = mock.MagicMock(  # type: ignore
+            return_value=channel,
+        )
+        reminders.start_reminder(
+            client,
+            # Run in roughly 10 ms
+            REMINDER._replace(name='a', delay_minutes=0.0001),  # type: ignore
+            ReminderType.ONE_TIME,
+        )
+        reminders.start_reminder(
+            client,
+            REMINDER._replace(name='b', delay_minutes=0.0001),  # type: ignore
+            ReminderType.REPEATING,
+        )
+
+        key_a = ReminderTaskKey(REMINDER.guild_id, 'a')
+        key_b = ReminderTaskKey(REMINDER.guild_id, 'b')
+        value_a = reminders._tasks[key_a]
+        value_b = reminders._tasks[key_b]
+
+        # Sleep for 50 ms to ensure task runs
+        await asyncio.sleep(0.05)
+
+        assert key_a not in reminders._tasks
+        assert key_b in reminders._tasks
+        reminders.stop_reminder(REMINDER.guild_id, 'b')
+
+        assert mock_send.await_count >= 1
+
+        await value_a.task._task
+        with pytest.raises(asyncio.exceptions.CancelledError):
+            await value_b.task._task
+
+
+@pytest.mark.asyncio
+async def test_create_one_time(reminders) -> None:
+    create_ = extract(reminders.create)
+
+    interaction = MockInteraction(
+        reminders.create,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    with mock.patch.object(reminders, 'start_reminder'):
+        await create_(
+            reminders,
+            interaction,
+            ReminderType.ONE_TIME,
+            REMINDER.name,
+            REMINDER.text,
+            MockChannel('channel', 42),
+            REMINDER.delay_minutes,
+        )
+
+    assert reminders.database.get(REMINDER.guild_id, REMINDER.name) is None
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'Created' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_repeating(reminders) -> None:
+    create_ = extract(reminders.create)
+
+    interaction = MockInteraction(
+        reminders.create,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    with mock.patch.object(reminders, 'start_reminder'):
+        await create_(
+            reminders,
+            interaction,
+            ReminderType.REPEATING,
+            REMINDER.name,
+            REMINDER.text,
+            MockChannel('channel', 42),
+            REMINDER.delay_minutes,
+        )
+
+    assert reminders.database.get(REMINDER.guild_id, REMINDER.name) is not None
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'Created' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_alphanumeric_check(reminders) -> None:
+    create_ = extract(reminders.create)
+
+    interaction = MockInteraction(
+        reminders.create,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    with mock.patch.object(reminders, 'start_reminder'):
+        await create_(
+            reminders,
+            interaction,
+            ReminderType.REPEATING,
+            'not alphanumeric',
+            REMINDER.text,
+            MockChannel('channel', 42),
+            REMINDER.delay_minutes,
+        )
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'alphanumeric' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_name_exists(reminders) -> None:
+    create_ = extract(reminders.create)
+
+    interaction = MockInteraction(
+        reminders.create,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    key = ReminderTaskKey(REMINDER.guild_id, REMINDER.name)
+    reminders._tasks[key] = None
+    with mock.patch.object(reminders, 'start_reminder'):
+        await create_(
+            reminders,
+            interaction,
+            ReminderType.REPEATING,
+            REMINDER.name,
+            REMINDER.text,
+            MockChannel('channel', 42),
+            REMINDER.delay_minutes,
+        )
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'already exists' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_one_time_warn_long_delay(reminders) -> None:
+    create_ = extract(reminders.create)
+
+    interaction = MockInteraction(
+        reminders.create,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    with mock.patch.object(reminders, 'start_reminder'):
+        await create_(
+            reminders,
+            interaction,
+            ReminderType.ONE_TIME,
+            REMINDER.name,
+            REMINDER.text,
+            MockChannel('channel', 42),
+            WARN_ON_LONG_DELAY + 1,
+        )
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'long delays may be lost' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_info(reminders) -> None:
+    info_ = extract(reminders.info)
+
+    key = ReminderTaskKey(REMINDER.guild_id, REMINDER.name)
+    value = ReminderTask(ReminderType.ONE_TIME, REMINDER, None)
+    reminders._tasks[key] = value
+
+    interaction = MockInteraction(
+        reminders.info,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    with (
+        mock.patch.object(interaction.client, 'get_user', return_value=None),
+        mock.patch.object(interaction.guild, 'get_channel', return_value=None),
+    ):
+        await info_(reminders, interaction, REMINDER.name)
+
+    assert interaction.responded
+    assert interaction.response_message is not None
+    assert REMINDER.name in interaction.response_message
+    assert REMINDER.text in interaction.response_message
+    assert ReminderType.ONE_TIME.value in interaction.response_message
+
+
+@pytest.mark.asyncio
+async def test_info_empty(reminders) -> None:
+    info_ = extract(reminders.info)
+
+    interaction = MockInteraction(
+        reminders.info,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    await info_(reminders, interaction, REMINDER.name)
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'does not exist' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_list(reminders) -> None:
+    list_ = extract(reminders.list)
+
+    key = ReminderTaskKey(REMINDER.guild_id, 'a')
+    value = ReminderTask(
+        ReminderType.ONE_TIME,
+        REMINDER._replace(name='a'),
+        None,
+    )
+    reminders._tasks[key] = value
+
+    key = ReminderTaskKey(REMINDER.guild_id, 'b')
+    value = ReminderTask(
+        ReminderType.ONE_TIME,
+        REMINDER._replace(name='b'),
+        None,
+    )
+    reminders._tasks[key] = value
+
+    interaction = MockInteraction(
+        reminders.list,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    with mock.patch.object(
+        interaction.guild,
+        'get_channel',
+        return_value=None,
+    ):
+        await list_(reminders, interaction)
+
+    assert interaction.responded
+    assert interaction.response_message is not None
+    assert 'a:' in interaction.response_message
+    assert 'b:' in interaction.response_message
+
+
+@pytest.mark.asyncio
+async def test_list_empty(reminders) -> None:
+    list_ = extract(reminders.list)
+
+    interaction = MockInteraction(
+        reminders.list,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    await list_(reminders, interaction)
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'no reminders' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove(reminders) -> None:
+    remove_ = extract(reminders.remove)
+
+    interaction = MockInteraction(
+        reminders.remove,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    key = ReminderTaskKey(REMINDER.guild_id, REMINDER.name)
+    value = ReminderTask(
+        ReminderType.ONE_TIME,
+        REMINDER,
+        mock.MagicMock(),
+    )
+    reminders._tasks[key] = value
+
+    assert key in reminders._tasks
+    await remove_(reminders, interaction, REMINDER.name)
+    assert key not in reminders._tasks
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'Removed' in interaction.response_message
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_missing(reminders) -> None:
+    remove_ = extract(reminders.remove)
+
+    interaction = MockInteraction(
+        reminders.remove,
+        user='user',
+        guild=MockGuild('guild', REMINDER.guild_id),
+    )
+
+    await remove_(reminders, interaction, REMINDER.name)
+
+    assert interaction.responded
+    assert (
+        interaction.response_message is not None
+        and 'does not exist' in interaction.response_message
+    )

--- a/tests/reminders/data_test.py
+++ b/tests/reminders/data_test.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from threepseat.reminders.data import Reminder
+from threepseat.reminders.data import Reminders
+from threepseat.reminders.data import UnknownReminderError
+
+
+VOICE_REMINDER = Reminder(
+    guild_id=1234,
+    channel_id=5678,
+    author_id=9012,
+    creation_time=0,
+    name='test',
+    text='test message',
+    delay_minutes=1,
+)
+
+
+def test_makes_parent_dirs(tmp_path: pathlib.Path) -> None:
+    db_parent_path = str(tmp_path / 'dir1' / 'dir2')
+    db_path = os.path.join(db_parent_path, 'test.db')
+    Reminders(db_path=db_path)
+    assert os.path.isdir(db_parent_path)
+
+
+def test_reminders_table_created(tmp_file: str) -> None:
+    reminders = Reminders(db_path=tmp_file)
+
+    with reminders.connect() as db:
+        res = db.execute(
+            'SELECT COUNT(*) FROM sqlite_master '
+            'WHERE type="table" AND name="reminders"',
+        ).fetchone()
+        assert res[0] == 1
+
+
+def test_add_get(tmp_file: str) -> None:
+    reminders = Reminders(db_path=tmp_file)
+
+    reminders.update(VOICE_REMINDER)
+    assert (
+        reminders.get(VOICE_REMINDER.guild_id, VOICE_REMINDER.name)
+        == VOICE_REMINDER
+    )
+
+
+def test_update(tmp_file: str) -> None:
+    reminders = Reminders(db_path=tmp_file)
+
+    reminders.update(VOICE_REMINDER)
+    reminders.update(VOICE_REMINDER._replace(text='new message'))
+    reminder = reminders.get(VOICE_REMINDER.guild_id, VOICE_REMINDER.name)
+    assert reminder is not None and reminder.text == 'new message'
+
+
+def test_all(tmp_file: str) -> None:
+    reminders = Reminders(db_path=tmp_file)
+
+    reminders.update(VOICE_REMINDER._replace(name='a'))
+    reminders.update(VOICE_REMINDER._replace(name='b'))
+    reminders.update(VOICE_REMINDER._replace(name='c'))
+    reminders.update(VOICE_REMINDER._replace(guild_id=1))
+    assert len(reminders.all(VOICE_REMINDER.guild_id)) == 3
+
+
+def test_remove(tmp_file: str) -> None:
+    reminders = Reminders(db_path=tmp_file)
+
+    reminders.update(VOICE_REMINDER)
+    assert (
+        reminders.get(VOICE_REMINDER.guild_id, VOICE_REMINDER.name)
+        == VOICE_REMINDER
+    )
+    reminders.remove(VOICE_REMINDER.guild_id, VOICE_REMINDER.name)
+    assert reminders.get(VOICE_REMINDER.guild_id, VOICE_REMINDER.name) is None
+
+
+def test_remove_missing(tmp_file: str) -> None:
+    reminders = Reminders(db_path=tmp_file)
+    with pytest.raises(UnknownReminderError):
+        reminders.remove(0, 'test')

--- a/tests/reminders/utils_test.py
+++ b/tests/reminders/utils_test.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+
+from testing.mock import MockChannel
+from testing.mock import MockClient
+from testing.mock import MockGuild
+from testing.mock import MockMember
+from testing.mock import MockUser
+from testing.mock import MockVoiceChannel
+from threepseat.reminders.data import Reminder
+from threepseat.reminders.data import ReminderType
+from threepseat.reminders.utils import reminder_task
+from threepseat.reminders.utils import send_text_reminder
+from threepseat.reminders.utils import send_voice_reminder
+
+REMINDER = Reminder(
+    guild_id=1234,
+    channel_id=5678,
+    author_id=9012,
+    creation_time=0,
+    name='test',
+    text='test message',
+    delay_minutes=0.0001,  # type: ignore
+)
+
+
+@pytest.mark.asyncio
+async def test_reminder_task() -> None:
+    with (
+        mock.patch(
+            'threepseat.reminders.utils.send_text_reminder',
+        ) as mock_text,
+        mock.patch(
+            'threepseat.reminders.utils.send_voice_reminder',
+        ) as mock_voice,
+    ):
+        client = MockClient(MockUser('user', 1234))
+        guild = MockGuild('guild', 5678)
+        text_channel = MockChannel('channel', 9012)
+        voice_channel = MockVoiceChannel()
+        client.get_guild = mock.MagicMock(return_value=guild)
+
+        guild.get_channel = mock.MagicMock(  # type: ignore
+            return_value=text_channel,
+        )
+        task = reminder_task(client, REMINDER, ReminderType.ONE_TIME, None)
+        task.start()
+        await asyncio.sleep(0.02)
+        assert mock_text.await_count == 1
+        task.cancel()
+
+        guild.get_channel = mock.MagicMock(  # type: ignore
+            return_value=voice_channel,
+        )
+        task = reminder_task(client, REMINDER, ReminderType.ONE_TIME, None)
+        task.start()
+        await asyncio.sleep(0.02)
+        assert mock_voice.await_count == 1
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_reminder_task_missing_guild(caplog) -> None:
+    caplog.set_level(logging.ERROR)
+    client = MockClient(MockUser('user', 1234))
+    client.get_guild = mock.MagicMock(return_value=None)
+
+    task = reminder_task(client, REMINDER, ReminderType.ONE_TIME, None)
+    task.start()
+    await asyncio.sleep(0.02)
+    task.cancel()
+
+    assert any(['find guild' in record.message for record in caplog.records])
+
+
+@pytest.mark.asyncio
+async def test_reminder_task_missing_channel(caplog) -> None:
+    caplog.set_level(logging.ERROR)
+    client = MockClient(MockUser('user', 1234))
+    guild = MockGuild('guild', 5678)
+    client.get_guild = mock.MagicMock(return_value=guild)
+    guild.get_channel = mock.MagicMock(return_value=None)  # type: ignore
+
+    task = reminder_task(client, REMINDER, ReminderType.ONE_TIME, None)
+    task.start()
+    await asyncio.sleep(0.02)
+    task.cancel()
+
+    assert any(
+        ['find text/voice' in record.message for record in caplog.records],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reminder_task_callback() -> None:
+    with mock.patch(
+        'threepseat.reminders.utils.send_text_reminder',
+    ) as mock_text:
+        client = MockClient(MockUser('user', 1234))
+        guild = MockGuild('guild', 5678)
+        text_channel = MockChannel('channel', 9012)
+        client.get_guild = mock.MagicMock(return_value=guild)
+
+        guild.get_channel = mock.MagicMock(  # type: ignore
+            return_value=text_channel,
+        )
+
+        callback = mock.MagicMock()
+        task = reminder_task(client, REMINDER, ReminderType.ONE_TIME, callback)
+        task.start()
+        await asyncio.sleep(0.02)
+        assert mock_text.await_count == 1
+        task.cancel()
+        assert callback.called
+
+
+@pytest.mark.asyncio
+async def test_send_text_reminder() -> None:
+    channel = MockChannel('channel')
+    message = 'test message'
+
+    with mock.patch.object(channel, 'send') as mock_send:
+        await send_text_reminder(channel, message)
+        assert mock_send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reminder() -> None:
+    client = MockClient(MockUser('user', 1234))
+    channel = MockVoiceChannel()
+    message = 'test message'
+
+    with (
+        mock.patch('threepseat.tts.gTTS'),
+        mock.patch('threepseat.reminders.utils.play_sound') as mock_play,
+    ):
+        await send_voice_reminder(client, channel, message)
+        assert mock_play.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_voice_reminder_skips_empty_channels() -> None:
+    client = MockClient(MockUser('user', 1234))
+    channel = MockVoiceChannel()
+    message = 'test message'
+
+    channel._members = [MockMember('user', 42, MockGuild('guild', 1234))]
+
+    with (
+        mock.patch('threepseat.tts.gTTS'),
+        mock.patch('threepseat.reminders.utils.play_sound') as mock_play,
+    ):
+        await send_voice_reminder(client, channel, message)
+        assert mock_play.await_count == 1

--- a/tests/tts_test.py
+++ b/tests/tts_test.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+from threepseat.tts import tts_as_mp3
+
+
+def test_tts_as_mp3() -> None:
+    with mock.patch('threepseat.tts.gTTS'):
+        with tts_as_mp3('test message') as fp:
+            filepath = fp
+            assert os.path.isfile(fp)
+        # File gets cleaned up
+        assert not os.path.isfile(filepath)

--- a/tests/tts_test.py
+++ b/tests/tts_test.py
@@ -3,7 +3,19 @@ from __future__ import annotations
 import os
 from unittest import mock
 
+import pytest
+
+from threepseat.tts import Accent
 from threepseat.tts import tts_as_mp3
+
+
+def test_accent_from_str() -> None:
+    assert Accent.from_str('AUSTRALIA') == Accent.AUSTRALIA
+
+    with pytest.raises(KeyError):
+        Accent.from_str('SOKOVIA')
+
+    assert isinstance(Accent.from_str('', random_if_unknown=True), Accent)
 
 
 def test_tts_as_mp3() -> None:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -110,7 +110,11 @@ async def test_play_sound(mock_audio) -> None:
     voice_client.move_to = mock.AsyncMock()  # type: ignore
     voice_client.play = mock.AsyncMock()  # type: ignore
 
-    voice_client.is_playing = mock.MagicMock(return_value=True)  # type: ignore
+    # Note: first True to see if there is a current sound to be stopped,
+    # then True to allow wait to happen, then False to exit wait loop
+    voice_client.is_playing = mock.MagicMock(  # type: ignore
+        side_effect=[True, True, False],
+    )
     voice_client.stop = mock.MagicMock()  # type: ignore
 
     with (
@@ -121,7 +125,7 @@ async def test_play_sound(mock_audio) -> None:
             new_callable=mock.PropertyMock(return_value=voice_client),
         ),
     ):
-        await play_sound(sound, channel)
+        await play_sound(sound, channel, wait=True)
 
     voice_client.is_playing = mock.MagicMock(  # type: ignore
         return_value=False,

--- a/threepseat/bot.py
+++ b/threepseat/bot.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 from threepseat.commands.commands import registered_app_commands
 from threepseat.commands.custom import CustomCommands
 from threepseat.listeners.listeners import registered_listeners
+from threepseat.reminders.commands import ReminderCommands
 from threepseat.rules.commands import RulesCommands
 from threepseat.sounds.commands import SoundCommands
 from threepseat.utils import leave_on_empty
@@ -26,6 +27,7 @@ class Bot(commands.Bot):
         custom_commands: CustomCommands | None = None,
         rules_commands: RulesCommands | None = None,
         sound_commands: SoundCommands | None = None,
+        reminder_commands: ReminderCommands | None = None,
     ) -> None:
         """Init Bot.
 
@@ -38,11 +40,14 @@ class Bot(commands.Bot):
                 object to register with bot (default: None).
             sound_commands (SoundCommands, optional): sound commands
                 object to register with bot (default: None).
+            reminder_commands (ReminderCommands, optional): reminder commands
+                object to register with bot (default: None).
         """
         self.playing_title = playing_title
         self.custom_commands = custom_commands
         self.rules_commands = rules_commands
         self.sound_commands = sound_commands
+        self.reminder_commands = reminder_commands
 
         intents = discord.Intents(
             guilds=True,
@@ -103,6 +108,11 @@ class Bot(commands.Bot):
             self.voice_channel_checker = leave_on_empty(self, 60)
             self.voice_channel_checker.start()
             logger.info('registered sound command group')
+
+        if self.reminder_commands is not None:
+            self.tree.add_command(self.reminder_commands)
+            self.reminder_commands.start_repeating_reminders(self)
+            logger.info('registered reminders command group')
 
         await self.tree.sync()
         for guild in self.guilds:

--- a/threepseat/commands/__init__.py
+++ b/threepseat/commands/__init__.py
@@ -4,6 +4,7 @@ import threepseat.commands.custom
 import threepseat.commands.emote
 import threepseat.commands.general
 import threepseat.commands.mmr
+import threepseat.commands.tts
 
 # We need to import these modules so the register decorators
 # actually run

--- a/threepseat/commands/custom.py
+++ b/threepseat/commands/custom.py
@@ -180,7 +180,7 @@ class CustomCommands(app_commands.Group):
         return [
             app_commands.Choice(name=command.name, value=command.name)
             for command in commands
-            if current.lower() in command.name.lower()
+            if current.lower() in command.name.lower() or current == ''
         ]
 
     @app_commands.command(

--- a/threepseat/commands/custom.py
+++ b/threepseat/commands/custom.py
@@ -195,8 +195,8 @@ class CustomCommands(app_commands.Group):
     async def create(
         self,
         interaction: discord.Interaction,
-        name: str,
-        description: str,
+        name: app_commands.Range[str, 1, 18],
+        description: app_commands.Range[str, 1, 50],
         body: str,
     ) -> None:
         """Create a custom command."""

--- a/threepseat/commands/mmr.py
+++ b/threepseat/commands/mmr.py
@@ -167,7 +167,7 @@ async def autocomplete_summoners(
     return [
         app_commands.Choice(name=item, value=item)
         for item in cache
-        if current.lower() in item.lower()
+        if current.lower() in item.lower() or current == ''
     ]
 
 

--- a/threepseat/commands/tts.py
+++ b/threepseat/commands/tts.py
@@ -12,6 +12,7 @@ from threepseat.tts import tts_as_mp3
 from threepseat.utils import play_sound
 from threepseat.utils import voice_channel
 
+MAX_TTS_CHARACTERS = 200
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 @app_commands.guild_only()
 async def tts(
     interaction: discord.Interaction,
-    text: str,
+    text: app_commands.Range[str, 1, MAX_TTS_CHARACTERS],
     accent: Accent = Accent.UNITED_STATES,
     slow: bool = False,
 ) -> None:

--- a/threepseat/commands/tts.py
+++ b/threepseat/commands/tts.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+
+from threepseat.commands.commands import log_interaction
+from threepseat.commands.commands import register_app_command
+from threepseat.tts import Accent
+from threepseat.tts import tts_as_mp3
+from threepseat.utils import play_sound
+from threepseat.utils import voice_channel
+
+
+logger = logging.getLogger(__name__)
+
+
+@register_app_command
+@app_commands.command(description='Read message as TTS in voice channel')
+@app_commands.describe(text='Text to convert to speech (max characters: 200)')
+@app_commands.describe(accent='Optional regional accent to use')
+@app_commands.describe(slow='Optionally read message slowly')
+@app_commands.check(log_interaction)
+@app_commands.guild_only()
+async def tts(
+    interaction: discord.Interaction,
+    text: str,
+    accent: Accent = Accent.UNITED_STATES,
+    slow: bool = False,
+) -> None:
+    """Read message as TTS in voice channel."""
+    assert interaction.guild is not None
+    assert isinstance(interaction.user, discord.Member)
+
+    if len(text) > 200:
+        await interaction.response.send_message(
+            'Text length is limited to 200 characters.',
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.defer(thinking=True, ephemeral=True)
+    channel = voice_channel(interaction.user)
+    if channel is None:
+        await interaction.followup.send(
+            'You must be in a voice channel to use TTS.',
+        )
+        return
+
+    try:
+        with tts_as_mp3(text, accent=accent, slow=slow) as fp:
+            await play_sound(fp, channel, wait=True)
+    except Exception as e:
+        await interaction.followup.send('Failed to play TTS.')
+        logger.exception(f'caught exception playing TTS: {e}')
+    else:
+        await interaction.followup.send('Played TTS!')

--- a/threepseat/main.py
+++ b/threepseat/main.py
@@ -13,6 +13,7 @@ from threepseat import config
 from threepseat.bot import Bot
 from threepseat.commands.custom import CustomCommands
 from threepseat.logging import configure_logging
+from threepseat.reminders.commands import ReminderCommands
 from threepseat.rules.commands import RulesCommands
 from threepseat.sounds.commands import SoundCommands
 from threepseat.sounds.data import Sounds
@@ -28,12 +29,14 @@ async def amain(cfg: config.Config, shutdown_event: asyncio.Event) -> None:
     rules_commands = RulesCommands(cfg.sqlite_database)
     sounds = Sounds(cfg.sqlite_database, cfg.sounds_path)
     sound_commands = SoundCommands(sounds)
+    reminder_commands = ReminderCommands(cfg.sqlite_database)
 
     bot = Bot(
         playing_title=cfg.playing_title,
         custom_commands=custom_commands,
         rules_commands=rules_commands,
         sound_commands=sound_commands,
+        reminder_commands=reminder_commands,
     )
     webapp = create_app(
         bot=bot,

--- a/threepseat/reminders/commands.py
+++ b/threepseat/reminders/commands.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import datetime
+import logging
+import time
+from typing import NamedTuple
+
+import discord
+from discord import app_commands
+from discord.ext import tasks
+
+from threepseat.commands.commands import admin_or_owner
+from threepseat.commands.commands import log_interaction
+from threepseat.reminders.data import Reminder
+from threepseat.reminders.data import Reminders
+from threepseat.reminders.data import ReminderType
+from threepseat.reminders.utils import reminder_task
+from threepseat.utils import alphanumeric
+
+MAX_TEXT_LENGTH = 200
+WARN_ON_LONG_DELAY = 6 * 60
+
+logger = logging.getLogger(__name__)
+
+
+class ReminderTask(NamedTuple):
+    """Reminder Task Data."""
+
+    kind: ReminderType
+    reminder: Reminder
+    task: tasks.Loop[tasks.LF]
+
+
+class ReminderTaskKey(NamedTuple):
+    """Reminder Task Key."""
+
+    guild_id: int
+    name: str
+
+
+class ReminderCommands(app_commands.Group):
+    """App commands for reminders for text and voice channels."""
+
+    def __init__(self, db_path: str) -> None:
+        """Init ReminderCommands.
+
+        Args:
+            db_path (str): path to database to use.
+        """
+        # The database is just used for storing repeating tasks between
+        # bot restarts
+        self.database = Reminders(db_path)
+
+        # Finished tasks should be removed from this dict
+        self._tasks: dict[ReminderTaskKey, ReminderTask] = {}
+
+        super().__init__(
+            name='reminders',
+            description='Create reminders in text or voice channels',
+            guild_only=True,
+        )
+
+    def start_repeating_reminders(self, client: discord.Client) -> None:
+        """Start all enabled reminder tasks."""
+        for guild in client.guilds:
+            for reminder in self.database.all(guild.id):
+                self.start_reminder(client, reminder, ReminderType.REPEATING)
+
+    def start_reminder(
+        self,
+        client: discord.Client,
+        reminder: Reminder,
+        kind: ReminderType,
+    ) -> None:
+        """Start a new reminder task."""
+        key = ReminderTaskKey(reminder.guild_id, reminder.name)
+        if key in self._tasks:
+            return
+
+        def _remove_callback() -> None:
+            self._tasks.pop(key, None)
+
+        task = reminder_task(
+            client,
+            reminder,
+            kind,
+            _remove_callback if kind == ReminderType.ONE_TIME else None,
+        )
+        task.start()
+        self._tasks[key] = ReminderTask(kind, reminder, task)
+        logger.info(
+            f'started {kind.value} reminder task {reminder.name} in guild '
+            f'{reminder.guild_id} and channel {reminder.channel_id} ',
+        )
+
+    def stop_reminder(self, guild_id: int, name: str) -> None:
+        """Stop a running reminder task."""
+        key = ReminderTaskKey(guild_id, name)
+        value = self._tasks.pop(key, None)
+        if value is not None:
+            value.task.cancel()
+            logger.info(
+                f'cancelled reminder task {name} in guild {guild_id} '
+                f'and channel {value.reminder.channel_id}',
+            )
+
+    async def autocomplete(
+        self,
+        interaction: discord.Interaction,
+        current: str,
+    ) -> list[app_commands.Choice[str]]:
+        """Return list of reminders in the guild matching current query."""
+        assert interaction.guild is not None
+        name_kinds = [
+            (key.name, value.kind.value)
+            for key, value in self._tasks.items()
+            if interaction.guild.id == key.guild_id
+        ]
+        return [
+            app_commands.Choice(name=f'{name} ({kind})', value=name)
+            for name, kind in name_kinds
+            if current.lower() in name.lower() or current == ''
+        ]
+
+    @app_commands.command(
+        name='create',
+        description='[Admin Only] Create a new reminder',
+    )
+    @app_commands.describe(
+        kind='Choose a one-time or repeating reminder',
+        name='Name of the reminder (alphanumeric characters only)',
+        text=f'Reminder body text (max {MAX_TEXT_LENGTH} character)',
+        channel='Channel to send the reminder in',
+        delay='Delay before sending reminder/delay before repeating',
+    )
+    @app_commands.check(admin_or_owner)
+    @app_commands.check(log_interaction)
+    async def create(
+        self,
+        interaction: discord.Interaction,
+        kind: ReminderType,
+        name: str,
+        text: app_commands.Range[str, 1, MAX_TEXT_LENGTH],
+        channel: discord.TextChannel | discord.VoiceChannel,
+        delay: app_commands.Range[int, 1, None],
+    ) -> None:
+        """Create a new reminder."""
+        assert interaction.guild is not None
+
+        if not alphanumeric(name):
+            await interaction.response.send_message(
+                'The reminder name must contain alphanumeric characters only',
+                ephemeral=True,
+            )
+            return
+
+        key = ReminderTaskKey(interaction.guild.id, name)
+        if key in self._tasks:
+            await interaction.response.send_message(
+                f'A reminder named *{name}* already exists.',
+                ephemeral=True,
+            )
+            return
+
+        reminder = Reminder(
+            guild_id=interaction.guild.id,
+            channel_id=channel.id,
+            author_id=interaction.user.id,
+            creation_time=int(time.time()),
+            name=name,
+            text=text,
+            delay_minutes=delay,
+        )
+
+        if kind == ReminderType.REPEATING:
+            self.database.update(reminder)
+
+        self.start_reminder(
+            interaction.client,
+            reminder,
+            kind,
+        )
+
+        msg = f'Created {kind.value} reminder named *{name}*.'
+        if delay > WARN_ON_LONG_DELAY and kind == ReminderType.ONE_TIME:
+            msg = (
+                f'{msg} Note that one-time reminders with very long delays '
+                'may be lost if the bot restarts. Repeating reminders persist '
+                'across bot restarts.'
+            )
+
+        await interaction.response.send_message(msg, ephemeral=True)
+        logger.info(f'created new reminder: {reminder}')
+
+    @app_commands.command(
+        name='info',
+        description='Get info about a reminder',
+    )
+    @app_commands.describe(name='Name of reminder to query')
+    @app_commands.autocomplete(name=autocomplete)
+    @app_commands.check(log_interaction)
+    async def info(self, interaction: discord.Interaction, name: str) -> None:
+        """Get info about a reminder."""
+        assert interaction.guild is not None
+
+        key = ReminderTaskKey(interaction.guild.id, name)
+        if key not in self._tasks:
+            await interaction.response.send_message(
+                f'A reminder named *{name}* does not exist.',
+                ephemeral=True,
+            )
+            return
+        value = self._tasks[key]
+        reminder = value.reminder
+
+        user = interaction.client.get_user(reminder.author_id)
+        user_str = user.mention if user is not None else 'unknown'
+        channel = interaction.guild.get_channel(reminder.channel_id)
+        channel_str = channel.mention if channel is not None else 'unknown'
+        date = datetime.datetime.fromtimestamp(
+            reminder.creation_time,
+        ).strftime('%B %d, %Y')
+        msg = (
+            f'Reminder *{reminder.name}* ({value.kind.value}):\n'
+            f' - message: {reminder.text}\n'
+            f' - channel: {channel_str}\n'
+            f' - delay: {reminder.delay_minutes} minute(s)n'
+            f' - author: {user_str}\n'
+            f' - created: {date}\n'
+        )
+
+        await interaction.response.send_message(msg, ephemeral=True)
+
+    @app_commands.command(
+        name='list',
+        description='List all reminders in the guild',
+    )
+    @app_commands.check(log_interaction)
+    async def list(self, interaction: discord.Interaction) -> None:
+        """List reminder in the guild."""
+        assert interaction.guild is not None
+
+        reminders = [
+            value
+            for key, value in self._tasks.items()
+            if interaction.guild.id == key.guild_id
+        ]
+        if len(reminders) == 0:
+            await interaction.response.send_message(
+                'There are no reminders in this guild yet.',
+                ephemeral=True,
+            )
+            return
+
+        lines = []
+        for value in reminders:
+            channel = interaction.guild.get_channel(value.reminder.channel_id)
+            channel_str = channel.mention if channel is not None else 'unknown'
+            lines.append(
+                f'{value.reminder.name}: {value.kind.value} reminder in '
+                f'{channel_str}',
+            )
+
+        lines_str = '\n - '.join(lines)
+        msg = f'Exisiting reminders:\n - {lines_str}'
+
+        await interaction.response.send_message(msg, ephemeral=True)
+
+    @app_commands.command(
+        name='remove',
+        description='[Admin Only] Remove a reminder',
+    )
+    @app_commands.describe(name='Name of reminder to remove')
+    @app_commands.autocomplete(name=autocomplete)
+    @app_commands.check(admin_or_owner)
+    @app_commands.check(log_interaction)
+    async def remove(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        """Remove a reminder."""
+        assert interaction.guild is not None
+
+        key = ReminderTaskKey(interaction.guild.id, name)
+        if key not in self._tasks:
+            await interaction.response.send_message(
+                f'A reminder named *{name}* does not exist.',
+                ephemeral=True,
+            )
+            return
+
+        self.stop_reminder(interaction.guild.id, name)
+        await interaction.response.send_message(
+            f'Removed the reminder *{name}*.',
+            ephemeral=True,
+        )

--- a/threepseat/reminders/commands.py
+++ b/threepseat/reminders/commands.py
@@ -139,7 +139,7 @@ class ReminderCommands(app_commands.Group):
         self,
         interaction: discord.Interaction,
         kind: ReminderType,
-        name: str,
+        name: app_commands.Range[str, 1, 18],
         text: app_commands.Range[str, 1, MAX_TEXT_LENGTH],
         channel: discord.TextChannel | discord.VoiceChannel,
         delay: app_commands.Range[int, 1, None],
@@ -147,9 +147,10 @@ class ReminderCommands(app_commands.Group):
         """Create a new reminder."""
         assert interaction.guild is not None
 
-        if not alphanumeric(name):
+        if not alphanumeric(name) or len(name) == 0:
             await interaction.response.send_message(
-                'The reminder name must contain alphanumeric characters only',
+                'The reminder must be a single word with only '
+                'alphanumeric characters.',
                 ephemeral=True,
             )
             return

--- a/threepseat/reminders/data.py
+++ b/threepseat/reminders/data.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import contextlib
+import enum
+import functools
+import os
+import sqlite3
+from collections.abc import Generator
+from typing import NamedTuple
+
+from threepseat.database import create_table
+from threepseat.database import named_tuple_parameters
+from threepseat.database import named_tuple_parameters_update
+
+
+class UnknownReminderError(Exception):
+    """Exception raised when modifying a reminder that does not exist."""
+
+    pass
+
+
+class ReminderType(enum.Enum):
+    """Reminder Type."""
+
+    ONE_TIME = 'one-time'
+    REPEATING = 'repeating'
+
+
+class Reminder(NamedTuple):
+    """Row in reminder table.
+
+    guild_id and name serve as a compound primary key.
+    """
+
+    guild_id: int
+    """Guild this reminder is configured in."""
+    channel_id: int
+    """Channel ID to send reminedr in."""
+    author_id: int
+    """User who created the reminder."""
+    creation_time: int
+    """Unix timestamp of when reminder was created."""
+    name: str
+    """Name of the reminder. Used for administrative purposes."""
+    text: str
+    """Reminder message."""
+    delay_minutes: int
+    """Minutes between saying reminder message."""
+
+
+class Reminders:
+    """Reminders data manager."""
+
+    def __init__(self, db_path: str) -> None:
+        """Init Reminders.
+
+        Args:
+            db_path (str): path to sqlite database.
+        """
+        self.db_path = db_path
+
+        if len(os.path.dirname(self.db_path)) > 0:
+            os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+
+        self.all = functools.cache(self._all)
+        self.get = functools.cache(self._get)
+
+        with self.connect() as db:
+            create_table(db, 'reminders', Reminder)
+
+    @contextlib.contextmanager
+    def connect(self) -> Generator[sqlite3.Connection, None, None]:
+        """Database connection context manager."""
+        with contextlib.closing(sqlite3.connect(self.db_path)) as db:
+            with db:
+                yield db
+
+    def _all(self, guild_id: int) -> list[Reminder]:
+        """Get all reminders in guild."""
+        with self.connect() as db:
+            rows = db.execute(
+                'SELECT * FROM reminders WHERE guild_id = :guild_id',
+                {'guild_id': guild_id},
+            ).fetchall()
+            return [Reminder(*row) for row in rows]
+
+    def _get(self, guild_id: int, name: str) -> Reminder | None:
+        """Get specific reminder."""
+        with self.connect() as db:
+            rows = db.execute(
+                'SELECT * FROM reminders '
+                'WHERE guild_id = :guild_id AND name = :name',
+                {'guild_id': guild_id, 'name': name},
+            ).fetchall()
+            if len(rows) == 0:
+                return None
+            else:
+                return Reminder(*rows[0])
+
+    def update(self, reminder: Reminder) -> None:
+        """Add or update a reminder."""
+        with self.connect() as db:
+            res = db.execute(
+                'UPDATE reminders '
+                f'SET {named_tuple_parameters_update(Reminder)} '
+                'WHERE guild_id = :guild_id AND name = :name',
+                reminder._asdict(),
+            )
+            if res.rowcount == 0:
+                res = db.execute(
+                    'INSERT INTO reminders VALUES '
+                    f'{named_tuple_parameters(Reminder)}',
+                    reminder._asdict(),
+                )
+            self.get.cache_clear()
+            self.all.cache_clear()
+
+    def remove(self, guild_id: int, name: str) -> None:
+        """Remove a reminder."""
+        reminder = self.get(guild_id, name)
+        if reminder is None:
+            raise UnknownReminderError()
+
+        with self.connect() as db:
+            db.execute(
+                'DELETE FROM reminders '
+                'WHERE name = :name AND guild_id = :guild_id',
+                {'guild_id': guild_id, 'name': name},
+            )
+
+        self.get.cache_clear()
+        self.all.cache_clear()

--- a/threepseat/reminders/utils.py
+++ b/threepseat/reminders/utils.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+import random
+from collections.abc import Callable
+
+import discord
+from discord.ext import tasks
+
+from threepseat.reminders.data import Reminder
+from threepseat.reminders.data import ReminderType
+from threepseat.tts import Accent
+from threepseat.tts import tts_as_mp3
+from threepseat.utils import play_sound
+
+logger = logging.getLogger(__name__)
+
+
+def reminder_task(
+    client: discord.Client,
+    reminder: Reminder,
+    kind: ReminderType,
+    callback: Callable[[], None] | None,
+) -> tasks.Loop[tasks.LF]:
+    """Return task that periodically sends reminder.
+
+    Usage:
+        >>> task = reminder_task(bot, Reminder(...), ReminderType.REPEATING)
+        >>> task.start()
+
+    Args:
+        client (Client): client/bot that performs reminders.
+        reminder (Reminder): reminder configuration.
+        kind (ReminderType): type of reminder to configure if tasks should
+            only run once.
+        callable (Callable): optional callable that takes no arguments that
+            will be executed after the task is finished. Note this is really
+            only relevant for one-time tasks.
+
+    Returns:
+        discord.ext.tasks.Loop
+    """
+
+    @tasks.loop(
+        minutes=reminder.delay_minutes,
+        # Note: count is 2 because we skip first loop
+        count=2 if kind == ReminderType.ONE_TIME else None,
+    )
+    async def _reminder() -> None:
+        if _reminder.current_loop == 0:
+            # Skip first loop so task actually does delay before first
+            # reminder.
+            return
+
+        guild = client.get_guild(reminder.guild_id)
+        if guild is None:
+            logger.error(
+                f'Failed to find guild {reminder.guild_id} for '
+                f'reminder named {reminder.name}',
+            )
+            return
+
+        channel = guild.get_channel(reminder.channel_id)
+        if isinstance(channel, discord.TextChannel):
+            await send_text_reminder(channel, reminder.text)
+        elif isinstance(channel, discord.VoiceChannel):
+            await send_voice_reminder(client, channel, reminder.text)
+        else:
+            logger.error(
+                f'Failed to find text/voice channel with ID '
+                f'{reminder.channel_id} in {guild.name} ({guild.id}) for '
+                f'reminder named {reminder.name}',
+            )
+            return
+
+        logger.info(
+            f'reminder {reminder.name} run for guild {guild.name} '
+            f'({guild.id}) in channel {channel.name} ({channel.id})',
+        )
+
+        if (
+            _reminder.current_loop == 1
+            and kind == ReminderType.ONE_TIME
+            and callback is not None
+        ):
+            callback()
+
+    return _reminder
+
+
+async def send_text_reminder(
+    channel: discord.TextChannel,
+    message: str,
+) -> None:
+    """Send message in text channel."""
+    await channel.send(message)
+
+
+async def send_voice_reminder(
+    client: discord.Client,
+    channel: discord.VoiceChannel,
+    message: str,
+) -> None:
+    """Send message as TTS in voice channel."""
+    client_id = -1 if client.user is None else client.user.id
+    members = [m for m in channel.members if m.id != client_id]
+    if len(members) == 0:
+        return
+
+    # Randomize voice
+    accent = Accent.from_str('', random_if_unknown=True)
+    slow = random.random() < 0.1
+
+    with tts_as_mp3(message, accent=accent, slow=slow) as fp:
+        await play_sound(fp, channel, wait=True)

--- a/threepseat/rules/commands.py
+++ b/threepseat/rules/commands.py
@@ -253,10 +253,10 @@ class RulesCommands(app_commands.Group):
         self,
         interaction: discord.Interaction,
         prefixes: str,
-        expectancy: float = 2 / 7,
-        duration: float = 60.0,
-        max_offenses: int = 3,
-        timeout: float = 3.0,
+        expectancy: app_commands.Range[float, 0.0, None] = 2 / 7,
+        duration: app_commands.Range[float, 1.0, None] = 60.0,
+        max_offenses: app_commands.Range[int, 1, None] = 3,
+        timeout: app_commands.Range[float, 0.0, None] = 3.0,
     ) -> None:
         """Configure events for a guild."""
         assert interaction.guild is not None

--- a/threepseat/sounds/commands.py
+++ b/threepseat/sounds/commands.py
@@ -82,7 +82,7 @@ class SoundCommands(app_commands.Group):
         return [
             app_commands.Choice(name=sound.name, value=sound.name)
             for sound in sounds
-            if current.lower() in sound.name.lower()
+            if current.lower() in sound.name.lower() or current == ''
         ]
 
     @app_commands.command(name='list', description='List available sounds')

--- a/threepseat/sounds/commands.py
+++ b/threepseat/sounds/commands.py
@@ -49,9 +49,9 @@ class SoundCommands(app_commands.Group):
     async def add(
         self,
         interaction: discord.Interaction,
-        name: str,
+        name: app_commands.Range[str, 1, 18],
         link: str,
-        description: str,
+        description: app_commands.Range[str, 1, 100],
     ) -> None:
         """Add a new sound."""
         await interaction.response.defer(thinking=True)

--- a/threepseat/tts.py
+++ b/threepseat/tts.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import contextlib
+import enum
+import tempfile
+from collections.abc import Generator
+
+from gtts import gTTS
+
+
+class Accent(enum.Enum):
+    """TLDs for English Accents."""
+
+    AUSTRALIA = 'com.au'
+    UNITED_KINGDOM = 'co.uk'
+    UNITED_STATES = 'com'
+    CANADA = 'ca'
+    INDIA = 'co.in'
+    IRELAND = 'ie'
+    SOUTH_AFRICA = 'co.za'
+
+
+@contextlib.contextmanager
+def tts_as_mp3(
+    text: str,
+    accent: Accent = Accent.UNITED_STATES,
+    slow: bool = False,
+) -> Generator[str, None, None]:
+    """Yield temporary TTS MP3 file.
+
+    Args:
+        text (str): text to convert to speech.
+        accent (Accent): regional English accent to use (default: US).
+        slow (bool): read text slower (default: False).
+
+    Yields:
+        Filepath (str) to MP3 TTS file. The file is temporary and will be
+        removed once the context is exited.
+    """
+    tts = gTTS(text, lang='en', tld=accent.value, slow=slow)
+    print(tts.write_to_fp)
+    with tempfile.NamedTemporaryFile() as fp:
+        tts.write_to_fp(fp)
+        yield fp.name

--- a/threepseat/tts.py
+++ b/threepseat/tts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import enum
+import random
 import tempfile
 from collections.abc import Generator
 
@@ -18,6 +19,30 @@ class Accent(enum.Enum):
     INDIA = 'co.in'
     IRELAND = 'ie'
     SOUTH_AFRICA = 'co.za'
+
+    @classmethod
+    def from_str(cls, name: str, random_if_unknown: bool = False) -> Accent:
+        """Convert string name to Accent.
+
+        Args:
+            name (str): name of accent.
+            random_if_unknown (bool): return a random accent rather than
+                raising an error if name is not a valid Accent name.
+
+        Returns:
+            Accent
+
+        Raises:
+            KeyError:
+                if random_if_unknown is False and name does not match an
+                Accent name.
+        """
+        try:
+            return cls[name]
+        except KeyError:
+            if random_if_unknown:
+                return random.choice(list(cls))
+            raise
 
 
 @contextlib.contextmanager
@@ -38,7 +63,6 @@ def tts_as_mp3(
         removed once the context is exited.
     """
     tts = gTTS(text, lang='en', tld=accent.value, slow=slow)
-    print(tts.write_to_fp)
     with tempfile.NamedTemporaryFile() as fp:
         tts.write_to_fp(fp)
         yield fp.name

--- a/threepseat/utils.py
+++ b/threepseat/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 import io
 import logging
@@ -64,8 +65,19 @@ def voice_channel(member: discord.Member) -> discord.VoiceChannel | None:
     return None
 
 
-async def play_sound(sound: str, channel: discord.VoiceChannel) -> None:
-    """Play a sound in the voice channel."""
+async def play_sound(
+    sound: str,
+    channel: discord.VoiceChannel,
+    wait: bool = False,
+) -> None:
+    """Play a sound in the voice channel.
+
+    Args:
+        sound (filepath): filepath to MP3 file to play.
+        channel (discord.VoiceChannel): voice channel to play sound in.
+        wait (bool): wait for sound to finish playing before exiting. Otherwise
+            the coroutine may return before the sound has finished.
+    """
     voice_client: discord.VoiceClient
     if channel.guild.voice_client is not None:
         await channel.guild.voice_client.move_to(channel)  # type: ignore
@@ -81,6 +93,10 @@ async def play_sound(sound: str, channel: discord.VoiceChannel) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         voice_client.play(source, after=None)
+
+    if wait:
+        while voice_client.is_playing():
+            await asyncio.sleep(0.1)
 
 
 def leave_on_empty(


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Adds:
- reminders extension for setting text and voice reminders
- `/tts` command to read a message in a voice channel with TTS

Updates:
- discord.py version
- constrain command parameters where possible with `app_commands.Range`
- return all autocomplete options when the current search is empty

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #17 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [x] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

New tests added and existing tests pass.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
