### PR TITLE
Add random offset for repeating reminders

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = threepseat
-version = 2.1.1
+version = 2.1.2
 description = 3pseatBot: a Discord Bot
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/threepseat/__init__.py
+++ b/threepseat/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Adds a random offset (sleep before the first loop) of repeating reminders to minimize the chances of two triggering at the same time when they have periods that are multiples of each other.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #50 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Unit tests pass and tested functionality in dev guild.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
