### PR TITLE
3pseatBot v2.1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = threepseat
-version = 2.1.3
+version = 2.1.4
 description = 3pseatBot: a Discord Bot
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/ext/rules/commands_test.py
+++ b/tests/ext/rules/commands_test.py
@@ -206,11 +206,11 @@ async def test_event_starter(commands) -> None:
         mock.patch.object(commands, 'start_event', mock.AsyncMock()) as mocked,
         mock.patch.object(client, 'get_guild', return_value=guild),
     ):
-        with mock.patch('random.random', return_value=0):
+        with mock.patch('random.random', return_value=1):
             await func()
             assert mocked.await_count == 0
 
-        with mock.patch('random.random', return_value=1.1):
+        with mock.patch('random.random', return_value=0):
             await func()
             assert mocked.await_count == 1
 

--- a/tests/ext/rules/commands_test.py
+++ b/tests/ext/rules/commands_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Generator
 from unittest import mock
 
@@ -213,6 +214,18 @@ async def test_event_starter(commands) -> None:
         with mock.patch('random.random', return_value=0):
             await func()
             assert mocked.await_count == 1
+
+        # Test cooldown prevents starting
+        config_orig = commands.database.get_config(GUILD_CONFIG.guild_id)
+        config_new = config_orig._replace(
+            event_cooldown=5,
+            last_event=time.time(),
+        )
+        commands.database.update_config(config_new)
+        await func()
+        assert mocked.await_count == 1
+        # Restore original config
+        commands.database.update_config(config_orig)
 
     with mock.patch.object(client, 'get_guild', return_value=None):
         await func()

--- a/threepseat/__init__.py
+++ b/threepseat/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = '2.1.3'
+__version__ = '2.1.4'

--- a/threepseat/ext/rules/commands.py
+++ b/threepseat/ext/rules/commands.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 import logging
 import random
+import time
 
 import discord
 from discord import app_commands
@@ -201,6 +202,10 @@ class RulesCommands(CommandGroupExtension):
             ),
         )
 
+        # Starting event success so update last_event time
+        config = config._replace(last_event=time.time())
+        self.database.update_config(config)
+
     async def stop_event(
         self,
         guild: discord.Guild,
@@ -326,7 +331,9 @@ class RulesCommands(CommandGroupExtension):
         last_event = (
             'never'
             if config.last_event == 0
-            else datetime.datetime.fromtimestamp(config.last_event)
+            else datetime.datetime.fromtimestamp(config.last_event).strftime(
+                '%-d %B %Y at %-I:%M:%S %p',
+            )
         )
         event_duration = readable_timedelta(minutes=config.event_duration)
         timeout_duration = readable_timedelta(minutes=config.timeout_duration)
@@ -484,7 +491,7 @@ class RulesCommands(CommandGroupExtension):
                 return
             last_offense = datetime.datetime.fromtimestamp(
                 user_data.last_offense,
-            ).strftime('%d %B %Y')
+            ).strftime('%-d %B %Y at %-I:%M:%S %p')
             await interaction.response.send_message(
                 f'{user.mention} currently has {user_data.current_offenses}/'
                 f'{config.max_offenses} offenses and '

--- a/threepseat/ext/rules/commands.py
+++ b/threepseat/ext/rules/commands.py
@@ -245,6 +245,14 @@ class RulesCommands(CommandGroupExtension):
                 guild = client.get_guild(config.guild_id)
                 if guild is None:
                     continue
+                # Skip if still in cooldown period
+                last_event_delta = time.time() - config.last_event
+                if (
+                    # Check > 0 in case current time is before last_event
+                    0 < last_event_delta < config.event_cooldown * 60
+                    and config.last_event > 0
+                ):
+                    continue
                 # Expectancy is expected number of events per day so scale
                 # by number of chances for an event to start per day. For
                 # example, if event_expectancy is 0.25 (one event every
@@ -267,9 +275,12 @@ class RulesCommands(CommandGroupExtension):
         prefixes='Comma-separated list of prefixes',
         expectancy=(
             'Expected number of event occurrences per day '
-            '(default: twice per week)'
+            '(default: 2/7, twice per week)'
         ),
-        duration='Duration of event in minutes (default: 1 hour)',
+        cooldown=(
+            'Cooldown between random events in minutes (default: 720 minutes)'
+        ),
+        duration='Duration of event in minutes (default: 60 minutes)',
         max_offenses='Max offenses before user is timed out (default: 3)',
         timeout='Minutes to timeout user for (default: 3 minutes)',
     )
@@ -280,6 +291,7 @@ class RulesCommands(CommandGroupExtension):
         interaction: discord.Interaction,
         prefixes: str,
         expectancy: app_commands.Range[float, 0.0, None] = 2 / 7,
+        cooldown: app_commands.Range[float, 0.0, None] = 720.0,
         duration: app_commands.Range[float, 1.0, None] = 60.0,
         max_offenses: app_commands.Range[int, 1, None] = 3,
         timeout: app_commands.Range[float, 0.0, None] = 3.0,
@@ -296,7 +308,7 @@ class RulesCommands(CommandGroupExtension):
             enabled=False,
             event_expectancy=expectancy,
             event_duration=duration,
-            event_cooldown=0,
+            event_cooldown=cooldown,
             last_event=0,
             max_offenses=max_offenses,
             timeout_duration=timeout,

--- a/threepseat/ext/rules/commands.py
+++ b/threepseat/ext/rules/commands.py
@@ -241,9 +241,13 @@ class RulesCommands(CommandGroupExtension):
                 if guild is None:
                     continue
                 # Expectancy is expected number of events per day so scale
-                # by number of chances for an event to start per day
+                # by number of chances for an event to start per day. For
+                # example, if event_expectancy is 0.25 (one event every
+                # four days) and chances per day is 24, p = 0.25/24.
+                # Then we pick a random number is trigger the event if less
+                # than p.
                 p = max(min(config.event_expectancy / chances_per_day, 1), 0)
-                if p <= random.random():
+                if random.random() <= p:
                     await self.start_event(guild)
 
         return _event_starter

--- a/threepseat/ext/sounds/web.py
+++ b/threepseat/ext/sounds/web.py
@@ -195,7 +195,7 @@ async def sound_grid(guild_id: int) -> Response:
         for sound in sound_list
     ]
 
-    sound_data.sort(key=lambda x: x.name)
+    sound_data.sort(key=lambda x: x.name.lower())
 
     return await quart.render_template(
         'sounds.html',

--- a/threepseat/ext/sounds/web.py
+++ b/threepseat/ext/sounds/web.py
@@ -242,7 +242,7 @@ async def sound_play(guild_id: int, sound_name: str) -> Response:
 async def login() -> Response:  # pragma: no cover
     """Login with discord OAuth."""
     discord = quart.current_app.config['DISCORD_OAUTH2_SESSION']
-    return await discord.create_session()
+    return await discord.create_session(prompt=True)
 
 
 @sounds_blueprint.route('/logout/')
@@ -258,6 +258,7 @@ async def callback() -> Response:  # pragma: no cover
     """Discord OAuth callback route."""
     discord = quart.current_app.config['DISCORD_OAUTH2_SESSION']
     await discord.callback()
+    quart.session.permanent = True
     return quart.redirect(quart.url_for('sounds.guilds'))
 
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

- Discord OAuth on soundboard persist across session.
- Soundboard sorting is case-insensitive (#59).
- Fix math error in random rules events that make events happen too much.
- Fix `last_event` not updating after rules events (#60).
- Add event cooldown support.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #59 
- Fixes #60 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Unit tests updated and passed. Tested changes in test server.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
