### PR TITLE
Fix autocomplete choices exceeding API limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = threepseat
-version = 2.1.6
+version = 2.1.7
 description = 3pseatBot: a Discord Bot
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/threepseat/__init__.py
+++ b/threepseat/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = '2.1.6'
+__version__ = '2.1.7'

--- a/threepseat/ext/custom/commands.py
+++ b/threepseat/ext/custom/commands.py
@@ -13,6 +13,7 @@ from threepseat.commands.commands import log_interaction
 from threepseat.ext.custom.data import CustomCommand
 from threepseat.ext.custom.data import CustomCommandTable
 from threepseat.ext.extension import CommandGroupExtension
+from threepseat.ext.extension import MAX_CHOICES_LENGTH
 from threepseat.utils import alphanumeric
 
 logger = logging.getLogger(__name__)
@@ -103,11 +104,12 @@ class CustomCommands(CommandGroupExtension):
     ) -> list[app_commands.Choice[str]]:
         """Return list of custom commands in the guild matching current."""
         assert interaction.guild is not None
-        return [
+        choices = [
             app_commands.Choice(name=command.name, value=command.name)
             for command in self.table.all(interaction.guild.id)
             if current.lower() in command.name.lower() or current == ''
         ]
+        return choices[: min(len(choices), MAX_CHOICES_LENGTH)]
 
     @app_commands.command(
         name='create',

--- a/threepseat/ext/extension.py
+++ b/threepseat/ext/extension.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import discord
 from discord import app_commands
 
+MAX_CHOICES_LENGTH = 25
+
 
 class CommandGroupExtension(app_commands.Group):
     """Base class for 3pseatBot command group extensions."""

--- a/threepseat/ext/games/commands.py
+++ b/threepseat/ext/games/commands.py
@@ -10,6 +10,7 @@ from discord import app_commands
 from threepseat.commands.commands import admin_or_owner
 from threepseat.commands.commands import log_interaction
 from threepseat.ext.extension import CommandGroupExtension
+from threepseat.ext.extension import MAX_CHOICES_LENGTH
 from threepseat.ext.games.data import Game
 from threepseat.ext.games.data import GamesTable
 
@@ -42,11 +43,12 @@ class GamesCommands(CommandGroupExtension):
         assert interaction.guild is not None
         games = self.table.all(interaction.guild.id)
         games.sort(key=lambda g: g.name)
-        return [
+        choices = [
             app_commands.Choice(name=game.name, value=game.name)
             for game in games
             if current.lower() in game.name.lower() or current == ''
         ]
+        return choices[: min(len(choices), MAX_CHOICES_LENGTH)]
 
     @app_commands.command(
         name='add',

--- a/threepseat/ext/reminders/commands.py
+++ b/threepseat/ext/reminders/commands.py
@@ -12,6 +12,7 @@ from discord.ext import tasks
 from threepseat.commands.commands import admin_or_owner
 from threepseat.commands.commands import log_interaction
 from threepseat.ext.extension import CommandGroupExtension
+from threepseat.ext.extension import MAX_CHOICES_LENGTH
 from threepseat.ext.reminders.data import Reminder
 from threepseat.ext.reminders.data import RemindersTable
 from threepseat.ext.reminders.data import ReminderType
@@ -118,11 +119,12 @@ class ReminderCommands(CommandGroupExtension):
             for key, value in self._tasks.items()
             if interaction.guild.id == key.guild_id
         ]
-        return [
+        choices = [
             app_commands.Choice(name=f'{name} ({kind})', value=name)
             for name, kind in name_kinds
             if current.lower() in name.lower() or current == ''
         ]
+        return choices[: min(len(choices), MAX_CHOICES_LENGTH)]
 
     @app_commands.command(
         name='create',

--- a/threepseat/ext/sounds/commands.py
+++ b/threepseat/ext/sounds/commands.py
@@ -10,6 +10,7 @@ from discord import app_commands
 from threepseat.commands.commands import admin_or_owner
 from threepseat.commands.commands import log_interaction
 from threepseat.ext.extension import CommandGroupExtension
+from threepseat.ext.extension import MAX_CHOICES_LENGTH
 from threepseat.ext.sounds.data import MemberSound
 from threepseat.ext.sounds.data import MemberSoundTable
 from threepseat.ext.sounds.data import SoundsTable
@@ -122,11 +123,12 @@ class SoundCommands(CommandGroupExtension):
     ) -> list[app_commands.Choice[str]]:
         """Return list of sound choices matching current."""
         assert interaction.guild is not None
-        return [
+        choices = [
             app_commands.Choice(name=sound.name, value=sound.name)
             for sound in self.table.all(interaction.guild.id)
             if current.lower() in sound.name.lower() or current == ''
         ]
+        return choices[: min(len(choices), MAX_CHOICES_LENGTH)]
 
     @app_commands.command(name='list', description='List available sounds')
     @app_commands.check(log_interaction)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

The discord API limits command choices (e.g., for autocomplete) to 25, so we'll just send the first 25 matching.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->


### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested locally.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
