### PR TITLE
Update data.py with new sound name character limit

### DIFF
--- a/threepseat/ext/sounds/data.py
+++ b/threepseat/ext/sounds/data.py
@@ -68,14 +68,14 @@ class SoundsTable(SQLTableInterface[Sound]):
             ValueError:
                 if name contains non-alphanumeric characters.
             ValueError:
-                if name is not between 1 and 12 characters long.
+                if name is not between 1 and 15 characters long.
             ValueError:
                 any additional errors raises by download().
         """
         if not alphanumeric(name):
             raise ValueError('Name must contain only alphanumeric characters.')
-        if len(name) == 0 or len(name) > 12:
-            raise ValueError('Name must be between 1 and 12 characters long.')
+        if len(name) == 0 or len(name) > 15:
+            raise ValueError('Name must be between 1 and 15 characters long.')
 
         existing = self.get(name=name, guild_id=guild_id)
         if existing is not None:

--- a/threepseat/ext/sounds/templates/sounds.html
+++ b/threepseat/ext/sounds/templates/sounds.html
@@ -49,6 +49,17 @@
       .btn:active {
         background-color: #558b2f;
       }
+      .card .card-content {
+        padding-top: 16px;
+        padding-bottom: 16px;
+        padding-left: 24px;
+        padding-right: 24px;
+      }
+      .card .card-content .card-title {
+        font-size: 19px;
+        line-height: 28px;
+        font-weight: 500;
+      }
     </style>
 </head>
 


### PR DESCRIPTION
Character limit on sound names upped to 15 characters

# Description
It is increasingly common to have a phrase just over the 12-character limit but still within a reasonable 15 characters—proposing a slight increase in the sound name character limit.