### PR TITLE
Fix coverage in test case

### DIFF
--- a/tests/bot_test.py
+++ b/tests/bot_test.py
@@ -65,7 +65,7 @@ async def test_bot_startup(tmp_file: str, caplog) -> None:
             new_callable=mock.PropertyMock(
                 return_value=[MockGuild('guild', 1234)],
             ),
-        ):
+        ):  # pragma: no branch
             bot = Bot(extensions=extensions)
             await bot.on_ready()
 

--- a/tests/ext/rules/commands_test.py
+++ b/tests/ext/rules/commands_test.py
@@ -156,7 +156,10 @@ async def test_start_event(commands) -> None:
         'threepseat.ext.rules.commands.primary_channel',
         return_value=None,
     ):
-        with pytest.raises(EventStartError, match='not find valid text'):
+        with pytest.raises(
+            EventStartError,
+            match='not find valid text',
+        ):  # pragma: no branch
             await commands.start_event(guild)
 
     with (

--- a/tests/ext/sounds/web_test.py
+++ b/tests/ext/sounds/web_test.py
@@ -45,7 +45,7 @@ async def quart_app(
             redirect_uri='http://localhost:5001',
         )
 
-        async with app.test_app() as test_app:
+        async with app.test_app() as test_app:  # pragma: no branch
             yield test_app
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -78,7 +78,10 @@ def test_primary_channel() -> None:
         with mock.patch('discord.VoiceChannel'):
             channel = discord.VoiceChannel()  # type: ignore
         guild._channels = {'c1': channel}  # type: ignore
-        with mock.patch('threepseat.utils.isinstance', return_value=False):
+        with mock.patch(
+            'threepseat.utils.isinstance',
+            return_value=False,
+        ):  # pragma: no branch
             assert primary_channel(guild) is None
 
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

I think this may be a regression in coverage. It seems there are cases
where a nested context manager is treated as a branch where the branch
is uncovered. I don't have time at the moment to look into this, so just
fixing with pragmas. (I will look into it separately and open a
coverage issue.)

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
