### PR TITLE
Fix double birthday messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threepseat"
-version = "2.1.21"
+version = "2.1.22"
 authors = [
     {name = "Greg Pauloski", email = "jgpauloski@uchicago.edu"},
 ]

--- a/tests/ext/birthdays/commands_test.py
+++ b/tests/ext/birthdays/commands_test.py
@@ -53,44 +53,6 @@ async def test_birthday_task(birthdays) -> None:
 
 
 @pytest.mark.asyncio
-async def test_birthday_task_sleeps_until_start(birthdays) -> None:
-    from threepseat.ext.birthdays import commands
-
-    with mock.patch('discord.Client'):
-        client = discord.Client()  # type: ignore
-        client.guilds = []  # type: ignore
-
-    with mock.patch('asyncio.sleep'):
-        original_check_hour = commands.BIRTHDAY_CHECK_HOUR
-        original_check_minute = commands.BIRTHDAY_CHECK_MINUTE
-        # Force next birthday check time to be in future
-        commands.BIRTHDAY_CHECK_HOUR = 23
-        commands.BIRTHDAY_CHECK_MINUTE = 59
-
-        task = birthdays.birthday_task(client)
-        task.change_interval(seconds=0.005)
-        task.start()
-        while task.current_loop == 0:
-            await asleep(0.01)
-        task.cancel()
-
-        # Force next birthday check time to be in past
-        commands.BIRTHDAY_CHECK_HOUR = 0
-        commands.BIRTHDAY_CHECK_MINUTE = 0
-
-        task = birthdays.birthday_task(client)
-        task.change_interval(seconds=0.005)
-        task.start()
-        while task.current_loop == 0:
-            await asleep(0.01)
-        task.cancel()
-
-        # Restore values
-        commands.BIRTHDAY_CHECK_HOUR = original_check_hour
-        commands.BIRTHDAY_CHECK_MINUTE = original_check_minute
-
-
-@pytest.mark.asyncio
 async def test_send_birthday_messages(birthdays) -> None:
     guild = MockGuild('guild', BIRTHDAY.guild_id)
     channel = MockChannel('channel', 42)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

The bot was sending birthday messages twice... this seemed to be because the first message happened in less than a second so the "sleep until next hour/minute" check would sleep for 0 seconds rather than 24 hours. (This is somewhat speculation based on the logs and reading the code).
```
[2025-07-31 08:59:59.105] INFO (threepseat.ext.birthdays.commands): starting daily birthday check...
[2025-07-31 08:59:59.469] INFO (threepseat.ext.birthdays.commands): finished daily birthday check
[2025-07-31 08:59:59.832] INFO (threepseat.ext.birthdays.commands): starting daily birthday check...
[2025-07-31 09:00:00.173] INFO (threepseat.ext.birthdays.commands): finished daily birthday check
```
Turns out discord-py tasks have a mechanism to run at a set time each day so I just switched to using that instead.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

N/A

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
