### PR TITLE
Fix timezone not found error in deployed container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pynacl",
     "quart>=0.19.2",
     "requests",
+    "tzdata",
     "yt-dlp",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "threepseat"
-version = "2.1.22"
+version = "2.1.23"
 authors = [
     {name = "Greg Pauloski", email = "jgpauloski@uchicago.edu"},
 ]

--- a/threepseat/ext/birthdays/commands.py
+++ b/threepseat/ext/birthdays/commands.py
@@ -70,7 +70,7 @@ class BirthdayCommands(CommandGroupExtension):
         time = datetime.time(
             hour=BIRTHDAY_CHECK_HOUR,
             minute=BIRTHDAY_CHECK_MINUTE,
-            tzinfo=zoneinfo.ZoneInfo('US/Central'),
+            tzinfo=zoneinfo.ZoneInfo('America/Chicago'),
         )
 
         @tasks.loop(time=time)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

```
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'tzdata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/discord/client.py", line 504, in _run_event
    await coro(*args, **kwargs)
  File "/bot/threepseat/bot.py", line 52, in on_ready
    await self.setup()
  File "/bot/threepseat/bot.py", line 82, in setup
    await ext.post_init(self)
  File "/bot/threepseat/ext/birthdays/commands.py", line 64, in post_init
    self._birthday_task = self.birthday_task(bot)
                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/bot/threepseat/ext/birthdays/commands.py", line 73, in birthday_task
    tzinfo=zoneinfo.ZoneInfo('US/Central'),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/zoneinfo/_common.py", line 24, in load_tzdata
    raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key US/Central'
```

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., mypy, ruff, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
